### PR TITLE
Feat/sonarqube examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ site
 
 # E2E test reports
 e2e-test-report/
+
+#Docker
+volumes

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ This will give you a backstage instance with Soundcheck installed and some sampl
 
 The backstage demo environment will be running at `http://localhost:7007`
 
+## SonarQube Checks
+
+The docker-compose file will stand up a local SonarQube server and bootstrap it with a test project with the following properties:
+
+```
+project name: test-project
+project key: test-project-key
+```
+
+The local SonarQube server can be accessed on `localhost:9000` by using the username `admin` and password `admin123` to login.
+
+SoundCheck checks have been configured to run against the `example website` entity which has been configured with the SonarQube annotation with a value that matches the SonarQube project key.
+
 ## Configure PagerDuty Checks
 
 ### 1. Setup pager duty service

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -107,6 +107,8 @@ soundcheck:
       $include: ./soundcheck/scm-fact-collector.yaml
     branch:
       $include: ./soundcheck/branch-fact-collector.yaml
+    sonarqube:
+      $include: ./soundcheck/sonarqube-fact-collector.yaml
 
     ## Uncomment these lines to add more example data
     # - type: url

--- a/conf/backstage/bootstrap.js
+++ b/conf/backstage/bootstrap.js
@@ -1,0 +1,26 @@
+var admin_username = process.env.SONARQUBE_ADMIN_USERNAME;
+var admin_password = process.env.SONARQUBE_ADMIN_PASSWORD;
+var base_url = `http://${process.env.SONARQUBE_HOST}:${process.env.SONARQUBE_PORT}`;
+
+fetch(
+  `${base_url}/api/users/change_password?login=${admin_username}&previousPassword=admin&password=${admin_password}`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization:
+        'Basic ' + Buffer.from(`${admin_username}:admin`).toString('base64'),
+    },
+  },
+).then(function (_) {
+  fetch(
+    `${base_url}/api/projects/create?project=test-project&name=test-project-key&mainBranch=main`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization:
+          'Basic ' +
+          Buffer.from(`${admin_username}:${admin_password}`).toString('base64'),
+      },
+    },
+  );
+});

--- a/conf/postgres/00_sonarqube.sql
+++ b/conf/postgres/00_sonarqube.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE sonar;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,85 @@
 version: '3'
 services:
   backstage:
+    container_name: backstage
     image: backstage
     environment:
       POSTGRES_HOST: db
       POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres-pass
       # Add your token here
       GITHUB_TOKEN: <INSERT_GITHUB_TOKEN>
       SPOTIFY_PLUGIN_LICENSE: <INSERT_LICENSE_KEY>
+      SONARQUBE_HOST: sonarqube
+      SONARQUBE_PORT: 9000
+      SONARQUBE_ADMIN_USERNAME: admin
+      SONARQUBE_ADMIN_PASSWORD: admin123
     ports:
       - '7007:7007'
     volumes:
       - ./soundcheck:/app/soundcheck
       - ./examples/:/app/examples
+      - ./conf/backstage/bootstrap.js:/bootstrap.js
+    command: sh -c " node /bootstrap.js && node packages/backend --config app-config.yaml"
+    networks:
+      - bridged
+    depends_on:
+      db:
+        condition: service_healthy
+      sonarqube:
+        condition: service_healthy
+
+  sonarqube:
+    container_name: sonarqube
+    image: sonarqube:9-community
+    environment:
+      SONAR_JDBC_URL: 'jdbc:postgresql://postgres:5432/sonar'
+      SONAR_JDBC_USERNAME: 'postgres'
+      SONAR_JDBC_PASSWORD: 'postgres-pass'
+    volumes:
+      - ./volumes/sonarqube/data:/opt/SonarQube/data
+      - ./volumes/sonarqube/extensions:/opt/SonarQube/extensions
+      - ./volumes/sonarqube/logs:/opt/SonarQube/logs
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget -qO- http://localhost:9000/api/system/status | grep -e ''"status":"UP"'' -e ''"status":"DB_MIGRATION_NEEDED"'' -e ''"status":"DB_MIGRATION_RUNNING"''',
+        ]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - bridged
+    expose:
+      - 9000
+    ports:
+      - '9000:9000'
+    depends_on:
+      db:
+        condition: service_healthy
+
   db:
+    container_name: postgres
     image: postgres
     restart: always
     environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres-pass'
+    volumes:
+      - './volumes/postgres:/var/lib/postgresql/data/'
+      - './conf/postgres:/docker-entrypoint-initdb.d/'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - bridged
+    ports:
+      - '5432:5432'
+
+networks:
+  bridged:
+    driver: bridge

--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -12,6 +12,8 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: example-website
+  annotations:
+    sonarqube.org/project-key: test-project-key
 spec:
   type: website
   lifecycle: experimental

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -41,6 +41,7 @@
     "@spotify/backstage-plugin-soundcheck-backend": "^0.13.5",
     "@spotify/backstage-plugin-soundcheck-backend-module-github": "^0.5.1",
     "@spotify/backstage-plugin-soundcheck-backend-module-scm": "^0.6.1",
+    "@spotify/backstage-plugin-soundcheck-backend-module-sonarqube": "^0.1.2",
     "@spotify/backstage-plugin-soundcheck-common": "^0.11.1",
     "@spotify/backstage-plugin-soundcheck-node": "^0.4.7",
     "@types/git-url-parse": "^9.0.3",

--- a/packages/backend/src/plugins/soundcheck.ts
+++ b/packages/backend/src/plugins/soundcheck.ts
@@ -4,15 +4,18 @@ import { PluginEnvironment } from '../types';
 import { GithubFactCollector } from '@spotify/backstage-plugin-soundcheck-backend-module-github';
 import { ScmFactCollector } from '@spotify/backstage-plugin-soundcheck-backend-module-scm';
 import { BranchCountFactCollector } from '../factcollectors/branchcount';
+import { SonarQubeFactCollector } from '@spotify/backstage-plugin-soundcheck-backend-module-sonarqube';
 
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   return SoundcheckBuilder.create({ ...env })
-  .addFactCollectors(
-    ScmFactCollector.create(env.config, env.logger),
-    GithubFactCollector.create(env.config, env.logger, env.cache),
-    BranchCountFactCollector.create(env.config, env.logger),
-    // CUSTOM OR 3P FACT COLLECTORS GO HERE
-  ).build();
+    .addFactCollectors(
+      ScmFactCollector.create(env.config, env.logger),
+      GithubFactCollector.create(env.config, env.logger, env.cache),
+      BranchCountFactCollector.create(env.config, env.logger),
+      SonarQubeFactCollector.create(env.logger),
+      // CUSTOM OR 3P FACT COLLECTORS GO HERE
+    )
+    .build();
 }

--- a/soundcheck/checks.yaml
+++ b/soundcheck/checks.yaml
@@ -162,3 +162,9 @@
     Repo has a description
   failedMessage: |
     Repo does not have a description
+- id: has_sonarqube_project
+  rule:
+    factRef: sonarqube:default/projects
+    path: $.paging.total
+    operator: greaterThan
+    value: 0

--- a/soundcheck/sonarqube-fact-collector.yaml
+++ b/soundcheck/sonarqube-fact-collector.yaml
@@ -1,0 +1,10 @@
+baseUrl: 'http://${SONARQUBE_HOST}:${SONARQUBE_PORT}'
+username: ${SONARQUBE_ADMIN_USERNAME}
+password: ${SONARQUBE_ADMIN_PASSWORD}
+collects:
+  - type: projects
+    filter:
+      - spec.type: 'website'
+    cache: false
+    frequency:
+      minutes: 1

--- a/soundcheck/tracks.yaml
+++ b/soundcheck/tracks.yaml
@@ -122,5 +122,15 @@
           name: Certified Level Two for Branch Protections and Number of Branches
           description: >
             Indicates whether the entity is level 2 certified for the Branch Protections and Number of Branches programs
-
-        
+- id: sonarqube
+  name: Sonarqube
+  ownerEntityRef: group:default/web
+  description: >
+    Indicates if SonarQube is configured for the entity
+  levels:
+    - ordinal: 1
+      checks:
+        - id: has_sonarqube_project
+          name: Has an associated SonarQube project
+          description: >
+            Indicates whether the entity has a SonarQube project setup for it.


### PR DESCRIPTION
adds soundcheck example for SonarQube fact collector

- updates docker-compose
  - stands up a container for a local SonarQube server
  - bootstraps the SonarQube server with a test project
- updates soundcheck
  - adds new track and check for SonarQube 
  - adds SonarQube fact collector filtering on entites of kind: Component and type: Website
  - adds SonarQube annotation to example website entity with value matching the bootstrapped test project